### PR TITLE
Update Google client credentials and keepAlive URL

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -36,7 +36,7 @@ function keepAlive(url) {
 
 // cron job to ping the server every minute and delete expired tokens every 5 minutes
 cron.schedule("*/5 * * * *", () => {
-  keepAlive("//");
+  keepAlive("https://coallab.onrender.com");
   deleteExpiredTokens();
   console.log("deleting expired tokens every 5 minutes");
   console.log("pinging the server every minute");

--- a/src/utils/passport.ts
+++ b/src/utils/passport.ts
@@ -86,9 +86,8 @@ passport.use(
 passport.use(
   new GoogleStrtegy(
     {
-      clientID:
-        "599847122048-vn5snb425g7jdfrui7s0kkrh9i3uubhp.apps.googleusercontent.com",
-      clientSecret: "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",
+      clientID: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
       callbackURL: "https://localhost:3000/api/v1/auth/google/callback",
     },
     async function (accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
This pull request updates the Google client credentials in passport.ts to use environment variables and updates the keepAlive URL to "https://coallab.onrender.com". This ensures that the client credentials are securely stored and that the keepAlive function pings the correct URL.